### PR TITLE
Creates .gitignore For Main Branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+package-lock.json


### PR DESCRIPTION
This is to prevent pushing node modules, package-lock.json, and .env to the repo